### PR TITLE
Add support for clang-format installed via a Python package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,12 @@ console_scripts =
     cmake-pc-lizard-hook = cmake_pc_hooks.lizard:main
 
 
+[options.extras_require]
+
+clang-format =
+         clang-format
+
+
 [bdist_wheel]
 universal = True
 


### PR DESCRIPTION
If `clang-format` cannot be found locally or in the current Python virtual environment (if any), add it to the list of required packages.

Closes #29 