### PR TITLE
Add support for linting/formatting CMake configured files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added Python tests using PyTest
 -   Added support for parsing hook parameters from TOML configuration files
 -   Added option to dump the current configuration as TOML-formatted output on the standard output (`--dump-toml`)
+-   Added option to parse CMake trace output to detect files generated using `configure_file(...)`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -186,17 +186,18 @@ none of the provided options is viable, the first one will automatically be sele
 
 In addition to the above CMake options, the hooks also accept the following:
 
-| Other hook options           | Description                                      | Note         |
-|------------------------------|--------------------------------------------------|--------------|
-| `--all-at-once`              | Pass all filenames to the command at once        | Since v1.4.0 |
-| `--clean`                    | Perform a clean CMake build                      | Since v1.4.0 |
-| `--cmake`                    | Specify path to CMake executable                 | Since v1.4.0 |
-| `--dump-toml`                | Dump the current configuration as TOML on stdout | Since v1.9.0 |
-| `--no-automatic-discovery`   | Disable automatic build directory discovery      | Since v1.9.0 |
-| `--read-json-db`             | Append file list from compile database           | Since v1.7.0 |
-| `--linux`                    | Linux-only CMake options                         | Since v1.3.0 |
-| `--mac`                      | MacOS-only CMake options                         | Since v1.3.0 |
-| `--win`                      | Windows-only CMake options                       | Since v1.3.0 |
+| Other hook options           | Description                                            | Note         |
+|------------------------------|--------------------------------------------------------|--------------|
+| `--all-at-once`              | Pass all filenames to the command at once              | Since v1.4.0 |
+| `--clean`                    | Perform a clean CMake build                            | Since v1.4.0 |
+| `--cmake`                    | Specify path to CMake executable                       | Since v1.4.0 |
+| `--detect-configured-files`  | Enable cmake tracing and detection of configured files | Since v1.9.0 |
+| `--dump-toml`                | Dump the current configuration as TOML on stdout       | Since v1.9.0 |
+| `--no-automatic-discovery`   | Disable automatic build directory discovery            | Since v1.9.0 |
+| `--read-json-db`             | Append file list from compile database                 | Since v1.7.0 |
+| `--linux`                    | Linux-only CMake options                               | Since v1.3.0 |
+| `--mac`                      | MacOS-only CMake options                               | Since v1.3.0 |
+| `--win`                      | Windows-only CMake options                             | Since v1.3.0 |
 
 NB: by specifying `--all-at-once` the linter/formatter command will only be called once for all the files instead of
 calling the command once per file.
@@ -267,6 +268,13 @@ build_dir = [ "/tmp/build",]
 dev_warnings = true
 ```
 
+### CMake configured file detection
+
+Since v1.9.0, the hooks support the use of CMake with trace mode enabled in order to keep track of files that are
+generated using calls to the `configure_file(...)` CMake function. If `--detect-configured-files` is specified on the command line
+(or in some TOML configuration file), the hooks will attempt to locate those generated files and automatically add them
+to the list of processed files for any hook invocation.
+
 ### Hook Option Comparison
 
 | Hook Options             | Fix In Place        | Enable all Checks                        | Set key/value |
@@ -278,7 +286,8 @@ dev_warnings = true
 
 [^1]: `-fix` will fail if there are compiler errors. `-fix-errors` will `-fix` and fix compiler errors if it can, like missing semicolons.
 
-[^2]: Be careful with `-checks=*`; some checks can have self-contradictory rules in newer versions of LLVM (9+). For example, modernize wants to use [trailing return type][] but Fuchsia [disallows it][].
+[^2]: Be careful with `-checks=*`; some checks can have self-contradictory rules in newer versions of LLVM (9+). For
+    example, modernize wants to use [trailing return type][] but Fuchsia [disallows it][].
 
 [trailing return type]: https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-trailing-return-type.html
 

--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ dev_warnings = true
 ### CMake configured file detection
 
 Since v1.9.0, the hooks support the use of CMake with trace mode enabled in order to keep track of files that are
-generated using calls to the `configure_file(...)` CMake function. If `--detect-configured-files` is specified on the command line
-(or in some TOML configuration file), the hooks will attempt to locate those generated files and automatically add them
-to the list of processed files for any hook invocation.
+generated using calls to the `configure_file(...)` CMake function. If `--detect-configured-files` is specified on the
+command line (or in some TOML configuration file), the hooks will attempt to locate those generated files and
+automatically add them to the list of processed files for any hook invocation.
 
 ### Hook Option Comparison
 

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -128,7 +128,9 @@ class CMakeCommand:
         options.add_argument('--clean', action='store_true', help='Start from a clean build directory')
         options.add_argument('--cmake', type=_argparse.executable_path, help='Specify path to CMake executable.')
         options.add_argument(
-            '--cmake-trace', action='store_true', help='Enable advanced tracing of CMake operations during configure'
+            '--detect-configured-files',
+            action='store_true',
+            help='Enable tracing of files generated  using the configure_file(...) CMake function',
         )
         options.add_argument(
             '--no-automatic-discovery',
@@ -243,7 +245,7 @@ class CMakeCommand:
             build_dir_list=cmake_args.build_dir, automatic_discovery=cmake_args.automatic_discovery
         )
 
-        if cmake_args.cmake_trace:
+        if cmake_args.detect_configured_files:
             self.cmake_trace_log = self.build_dir / self.DEFAULT_TRACE_LOG
 
         keyword_args = {

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -14,6 +14,7 @@
 
 """CMake related function and classes."""
 
+import contextlib
 import json
 import logging
 import os
@@ -403,9 +404,10 @@ class CMakeCommand:
             if json_data.get('cmd', '') != 'configure_file':
                 return False
 
-            return (self.source_dir.as_posix() in json_data['file']) and (
-                cmake_cache_variables.get('FETCHCONTENT_BASE_DIR', '') not in json_data['file']
-            )
+            is_relevant = self.source_dir.as_posix() in json_data['file']
+            with contextlib.suppress(KeyError):
+                is_relevant &= cmake_cache_variables['FETCHCONTENT_BASE_DIR'] not in json_data['file']
+            return is_relevant
 
         with self.cmake_trace_log.open('r') as fd:
             configure_file_calls = [json.loads(line) for line in fd.readlines()]

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -385,7 +385,7 @@ class CMakeCommand:
 
         cmake_cache_variables = {}
         for line in result.stdout.splitlines():
-            cmake_var = re.match(r'^([A-Za-z0-9_]+):(BOOL|FILEPATH|PATH|STRING|INTERNAL)=(.*)$', line)
+            cmake_var = re.match(r'^(\w+):(BOOL|FILEPATH|PATH|STRING|INTERNAL)=(.*)$', line)
             if cmake_var:
                 cmake_cache_variables[cmake_var.group(1)] = cmake_var.group(3)
 

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -403,7 +403,7 @@ class CMakeCommand:
             if json_data.get('cmd', '') != 'configure_file':
                 return False
 
-            return (str(self.source_dir) in json_data['file']) and (
+            return (self.source_dir.as_posix() in json_data['file']) and (
                 cmake_cache_variables.get('FETCHCONTENT_BASE_DIR', '') not in json_data['file']
             )
 

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -385,7 +385,7 @@ class CMakeCommand:
 
         cmake_cache_variables = {}
         for line in result.stdout.splitlines():
-            cmake_var = re.match(r'^([A-Za-z0-9_]+):(STRING|BOOL|FILEPATH|PATH|STRING)=(.*)$', line)
+            cmake_var = re.match(r'^([A-Za-z0-9_]+):(BOOL|FILEPATH|PATH|STRING|INTERNAL)=(.*)$', line)
             if cmake_var:
                 cmake_cache_variables[cmake_var.group(1)] = cmake_var.group(3)
 

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -14,9 +14,11 @@
 
 """CMake related function and classes."""
 
+import json
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess as sp
 import sys
@@ -87,6 +89,7 @@ class CMakeCommand:
     """Class used to encapsulate all CMake related functionality."""
 
     DEFAULT_BUILD_DIR = '.cmake_build'
+    DEFAULT_TRACE_LOG = 'trace_log.json'
 
     def __init__(self, cmake_names=None):
         """
@@ -98,8 +101,9 @@ class CMakeCommand:
         self.command = get_cmake_command(cmake_names)
         self.source_dir = None
         self.build_dir = None
-        self.build_dir_discovery = True
         self.cmake_args = ['-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON']
+        self.cmake_trace_log = None
+        self.cmake_configured_files = []
 
     def add_cmake_arguments_to_parser(self, parser):
         """Add CMake options to an argparse.ArgumentParser."""
@@ -123,6 +127,9 @@ class CMakeCommand:
         # Custom options
         options.add_argument('--clean', action='store_true', help='Start from a clean build directory')
         options.add_argument('--cmake', type=_argparse.executable_path, help='Specify path to CMake executable.')
+        options.add_argument(
+            '--cmake-trace', action='store_true', help='Enable advanced tracing of CMake operations during configure'
+        )
         options.add_argument(
             '--no-automatic-discovery',
             action='store_false',
@@ -183,7 +190,7 @@ class CMakeCommand:
             '-Wno-dev', dest='no_dev_warnings', action='store_true', help='Suppress developer warnings.'
         )
 
-    def resolve_build_directory(self, build_dir_list=None):
+    def resolve_build_directory(self, build_dir_list=None, automatic_discovery=True):
         """Locate a valid build directory based on internal list and automatic discovery if enabled."""
         # First try to locate a valid build directory based on internal list
         build_dir_list = [] if build_dir_list is None else [Path(path) for path in build_dir_list]
@@ -194,7 +201,7 @@ class CMakeCommand:
                 return
 
         # If that fails or none have been passed, attempt automatic discovery
-        if self.build_dir_discovery:
+        if automatic_discovery:
             for path in sorted(self.source_dir.glob('*')):
                 if path.is_dir() and (path / 'CMakeCache.txt').exists():
                     logging.info('Automatic build dir discovery resulted in: %s', str(path))
@@ -231,7 +238,13 @@ class CMakeCommand:
         self.source_dir = Path(cmake_args.source_dir).resolve()
         if cmake_args.cmake:
             self.command = [Path(cmake_args.cmake).resolve()]
-        self.build_dir_discovery = cmake_args.automatic_discovery
+
+        self.resolve_build_directory(
+            build_dir_list=cmake_args.build_dir, automatic_discovery=cmake_args.automatic_discovery
+        )
+
+        if cmake_args.cmake_trace:
+            self.cmake_trace_log = self.build_dir / self.DEFAULT_TRACE_LOG
 
         keyword_args = {
             'defines': ([], '-D{}'),
@@ -306,10 +319,30 @@ class CMakeCommand:
             logging.error('CMake configure step failed. See output for more information.')
             sys.exit(returncode)
 
+        if self.cmake_trace_log is not None:
+            self._parse_cmake_trace_log()
+
+    def _call_cmake(self, extra_args=None):
+        command = [str(cmd) for cmd in self.command]
+        if extra_args is None:
+            extra_args = []
+
+        result = _call_process.call_process(
+            [*command, str(self.source_dir), *self.cmake_args, *extra_args], cwd=str(self.build_dir)
+        )
+        result.stdout = '\n'.join(
+            [
+                f'Running CMake with: {[*command, str(self.source_dir), *self.cmake_args]}',
+                f'  from within {self.build_dir}',
+                result.stdout,
+                '',
+            ]
+        )
+
+        return result
+
     def _configure(self, lock_files, clean_build):
         """Run a CMake configure step."""
-        command = [str(cmd) for cmd in self.command]
-
         self.build_dir.mkdir(exist_ok=True)
 
         if clean_build:
@@ -319,15 +352,11 @@ class CMakeCommand:
                 elif path not in lock_files:
                     path.unlink()
 
-        result = _call_process.call_process([*command, str(self.source_dir), *self.cmake_args], cwd=str(self.build_dir))
-        result.stdout = '\n'.join(
-            [
-                f'Running CMake with: {[*command, str(self.source_dir), *self.cmake_args]}',
-                f'  from within {self.build_dir}',
-                result.stdout,
-                '',
-            ]
-        )
+        extra_args = []
+        if self.cmake_trace_log:
+            extra_args.extend(['--trace-expand', '--trace-format=json-v1', f'--trace-redirect={self.cmake_trace_log}'])
+
+        result = self._call_cmake(extra_args=extra_args)
 
         compiledb = Path(self.build_dir, 'compile_commands.json')
         if not compiledb.exists():
@@ -338,6 +367,53 @@ class CMakeCommand:
             result.to_stdout_and_stderr()
 
         return result.returncode
+
+    def _parse_cmake_trace_log(self):
+        logging.info('attempting to parse CMake trace log to detect calls to configure_file()')
+        self.cmake_configured_files = []
+
+        if not self.cmake_trace_log:
+            logging.info('no trace log provided, aborting.')
+            return
+
+        result = self._call_cmake(extra_args=['-N', '-LA'])
+        if result.returncode != 0:
+            logging.error('failed to retrieve CMake cache variables')
+            return
+
+        cmake_cache_variables = {}
+        for line in result.stdout.splitlines():
+            cmake_var = re.match(r'^([A-Za-z0-9_]+):(STRING|BOOL|FILEPATH|PATH|STRING)=(.*)$', line)
+            if cmake_var:
+                cmake_cache_variables[cmake_var.group(1)] = cmake_var.group(3)
+
+        # ------------------------------
+
+        def _is_relevant_configure_file_call(json_data):
+            """
+            Filter out the list of configure_file() calls.
+
+            The criteria are:
+              - Being a call to configure_file()
+              - Originating from a CMake file located inside the source directory
+              - Not originating from a CMake file located in FETCHCONTENT_BASE_DIR (if defined)
+            """
+            if json_data.get('cmd', '') != 'configure_file':
+                return False
+
+            return (str(self.source_dir) in json_data['file']) and (
+                cmake_cache_variables.get('FETCHCONTENT_BASE_DIR', '') not in json_data['file']
+            )
+
+        with self.cmake_trace_log.open('r') as fd:
+            configure_file_calls = [json.loads(line) for line in fd.readlines()]
+
+        for configure_file_call in (data for data in configure_file_calls if _is_relevant_configure_file_call(data)):
+            input_file, configured_file = (Path(arg) for arg in configure_file_call['args'][:2])
+            if not configured_file.is_absolute():
+                configured_file = self.build_dir / configured_file
+            logging.debug('detected call to configure_file(%s %s [...])', str(input_file), str(configured_file))
+            self.cmake_configured_files.append(str(configured_file))
 
 
 # ==============================================================================

--- a/cmake_pc_hooks/_utils.py
+++ b/cmake_pc_hooks/_utils.py
@@ -98,7 +98,6 @@ class Command(hooks.utils.Command):  # pylint: disable=too-many-instance-attribu
             raise RuntimeError('You *must* specify -B|--build-dir if you pass --preset as a CMake argument!')
 
         self.cmake.setup_cmake_args(known_args)
-        self.cmake.resolve_build_directory(known_args.build_dir)
 
         if not self.cmake.source_dir.exists() and not self.cmake.source_dir.is_dir():
             sys.stderr.write(f'{self.cmake.source_dir} is not a valid source directory\n')

--- a/cmake_pc_hooks/_utils.py
+++ b/cmake_pc_hooks/_utils.py
@@ -116,6 +116,8 @@ class Command(hooks.utils.Command):  # pylint: disable=too-many-instance-attribu
         self.cmake.configure(self.command)
         if self.read_json_db:
             self.files.extend(set(_read_compile_commands_json(self.cmake.build_dir)) - set(self.files))
+        self.files.extend(self.cmake.cmake_configured_files)
+
         if self.all_at_once:
             self.run_command(self.files)
         elif self.files:

--- a/tests/python/_cmake_test.py
+++ b/tests/python/_cmake_test.py
@@ -443,7 +443,7 @@ CMAKE_STATIC_LINKER_FLAGS_RELEASE:STRING=
 CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO:STRING=
 CMAKE_STRIP:FILEPATH=/usr/bin/strip
 CMAKE_VERBOSE_MAKEFILE:BOOL=FALSE
-FETCHCONTENT_BASE_DIR:PATH={tmp_path}/build/_deps
+FETCHCONTENT_BASE_DIR:PATH={tmp_path.as_posix()}/build/_deps
 FETCHCONTENT_FULLY_DISCONNECTED:BOOL=OFF
 FETCHCONTENT_QUIET:BOOL=ON
 FETCHCONTENT_SOURCE_DIR_CATCH2:PATH=
@@ -462,14 +462,16 @@ GIT_EXECUTABLE:FILEPATH=/usr/bin/git
 
     cmake_trace_log = tmp_path / 'log.json'
     cmake_trace_log.write_text(
-        f'''{{"version":{{"major":1,"minor":2}}}}
-{{"args":["VERSION","3.20"],"cmd":"cmake_minimum_required","file":"{tmp_path}/CMakeLists.txt","frame":1,"global_frame":1,"line":1,"time":1684940081.6217611}}
-{{"args":["test","LANGUAGES","CXX"],"cmd":"project","file":"{tmp_path}/CMakeLists.txt","frame":1,"global_frame":1,"line":3,"time":1684940081.6219001}}
-{{"args":["/usr/share/cmake/Modules/FetchContent/CMakeLists.cmake.in","{tmp_path}/build/_deps/catch2-subbuild/CMakeLists.txt"],"cmd":"configure_file","file":"/usr/share/cmake/Modules/FetchContent.cmake","frame":5,"global_frame":5,"line":1598,"line_end":1599,"time":1684940081.7072489}}
-{{"args":["{tmp_path}/build/_deps/catch2-src/src/catch2/catch_user_config.hpp.in","{tmp_path}/build/generated-includes/catch2/catch_user_config.hpp"],"cmd":"configure_file","file":"{tmp_path}/build/_deps/catch2-src/src/CMakeLists.txt","frame":1,"global_frame":4,"line":308,"line_end":311,"time":1684940082.2564831}}
-{{"args":["test.cpp.in","test.cpp"],"cmd":"configure_file","file":"{tmp_path}/CMakeLists.txt","frame":1,"global_frame":1,"line":17,"time":1684940082.260792}}
-{{"args":["test.cpp.in","{tmp_path}/other.cpp"],"cmd":"configure_file","file":"{tmp_path}/CMakeLists.txt","frame":1,"global_frame":1,"line":18,"time":1684940082.2613621}}
+        dedent(
+            f'''{{"version":{{"major":1,"minor":2}}}}
+{{"args":["VERSION","3.20"],"cmd":"cmake_minimum_required","file":"{tmp_path.as_posix()}/CMakeLists.txt","frame":1,"global_frame":1,"line":1,"time":1684940081.6217611}}
+{{"args":["test","LANGUAGES","CXX"],"cmd":"project","file":"{tmp_path.as_posix()}/CMakeLists.txt","frame":1,"global_frame":1,"line":3,"time":1684940081.6219001}}
+{{"args":["/usr/share/cmake/Modules/FetchContent/CMakeLists.cmake.in","{tmp_path.as_posix()}/build/_deps/catch2-subbuild/CMakeLists.txt"],"cmd":"configure_file","file":"/usr/share/cmake/Modules/FetchContent.cmake","frame":5,"global_frame":5,"line":1598,"line_end":1599,"time":1684940081.7072489}}
+{{"args":["{tmp_path.as_posix()}/build/_deps/catch2-src/src/catch2/catch_user_config.hpp.in","{tmp_path.as_posix()}/build/generated-includes/catch2/catch_user_config.hpp"],"cmd":"configure_file","file":"{tmp_path.as_posix()}/build/_deps/catch2-src/src/CMakeLists.txt","frame":1,"global_frame":4,"line":308,"line_end":311,"time":1684940082.2564831}}
+{{"args":["test.cpp.in","test.cpp"],"cmd":"configure_file","file":"{tmp_path.as_posix()}/CMakeLists.txt","frame":1,"global_frame":1,"line":17,"time":1684940082.260792}}
+{{"args":["test.cpp.in","{tmp_path.as_posix()}/other.cpp"],"cmd":"configure_file","file":"{tmp_path.as_posix()}/CMakeLists.txt","frame":1,"global_frame":1,"line":18,"time":1684940082.2613621}}
             '''
+        )
     )
 
     cmake = CMakeCommand()

--- a/tests/python/_test_utils.py
+++ b/tests/python/_test_utils.py
@@ -36,7 +36,7 @@ def run_command_default_assertions(
     sys_exit,
     exit_success=None,
     do_configure_test=True,
-    cmake_trace=False,
+    detect_configured_files=False,
     **kwargs,  # noqa: ARG001
 ):
     assert set(command.files) == {str(fname) for fname in file_list}
@@ -54,7 +54,7 @@ def run_command_default_assertions(
 
     if read_json_db:
         n_files += len(json_db_file_list)
-    if cmake_trace:
+    if detect_configured_files:
         n_files += len(command.cmake.cmake_configured_files)
 
     assert len(command.files) == n_files

--- a/tests/python/_test_utils.py
+++ b/tests/python/_test_utils.py
@@ -36,6 +36,7 @@ def run_command_default_assertions(
     sys_exit,
     exit_success=None,
     do_configure_test=True,
+    cmake_trace=False,
     **kwargs,  # noqa: ARG001
 ):
     assert set(command.files) == {str(fname) for fname in file_list}
@@ -49,10 +50,24 @@ def run_command_default_assertions(
     if exit_success is None:
         exit_success = returncode == 0
 
+    n_files = len(file_list)
+
     if read_json_db:
-        assert len(command.files) == len(file_list) + len(json_db_file_list)
-    else:
-        assert len(command.files) == len(file_list)
+        n_files += len(json_db_file_list)
+    if cmake_trace:
+        n_files += len(command.cmake.cmake_configured_files)
+
+    assert len(command.files) == n_files
+
+    for fname in file_list:
+        assert str(fname) in command.files
+
+    if read_json_db:
+        for fname in json_db_file_list:
+            assert str(fname) in command.files
+
+    for fname in command.cmake.cmake_configured_files:
+        assert str(fname) in command.files
 
     if all_at_once:
         call_process.assert_called_once()

--- a/tests/python/_utils_test.py
+++ b/tests/python/_utils_test.py
@@ -102,8 +102,9 @@ def test_command_parse_args_invalid(mocker, tmp_path, look_behind):
     sys_exit.assert_called_with(0)
 
 
+@pytest.mark.parametrize('cmake_trace', [False, True], ids=['no_trace', 'w_trace'])
 @pytest.mark.parametrize('parsing_failed', [False, True])
-def test_command_run(mocker, parsing_failed, setup_command):
+def test_command_run(mocker, parsing_failed, setup_command, cmake_trace):
     path = setup_command.compile_db_path
 
     # ----------------------------------
@@ -118,8 +119,12 @@ def test_command_run(mocker, parsing_failed, setup_command):
     command = _utils.Command(command_name, look_behind=False, args=args)
     command.parse_args(args)
 
+    if cmake_trace:
+        command.cmake.cmake_configured_files = ['configured.cpp']
+
     run_command_default_assertions(
         command=command,
+        cmake_trace=cmake_trace,
         exit_success=not parsing_failed,
         **setup_command._asdict(),
     )
@@ -150,6 +155,9 @@ def test_command_run_invalid(mocker, tmp_path):
 
     configure.assert_called_once_with(command.command)
     sys_exit.assert_called_once_with(1)
+
+
+# ==============================================================================
 
 
 def test_command_parse_output_invalid():

--- a/tests/python/_utils_test.py
+++ b/tests/python/_utils_test.py
@@ -102,9 +102,9 @@ def test_command_parse_args_invalid(mocker, tmp_path, look_behind):
     sys_exit.assert_called_with(0)
 
 
-@pytest.mark.parametrize('cmake_trace', [False, True], ids=['no_trace', 'w_trace'])
+@pytest.mark.parametrize('detect_configured_files', [False, True], ids=['no_file_detect', 'w_file_detect'])
 @pytest.mark.parametrize('parsing_failed', [False, True])
-def test_command_run(mocker, parsing_failed, setup_command, cmake_trace):
+def test_command_run(mocker, parsing_failed, setup_command, detect_configured_files):
     path = setup_command.compile_db_path
 
     # ----------------------------------
@@ -119,12 +119,12 @@ def test_command_run(mocker, parsing_failed, setup_command, cmake_trace):
     command = _utils.Command(command_name, look_behind=False, args=args)
     command.parse_args(args)
 
-    if cmake_trace:
+    if detect_configured_files:
         command.cmake.cmake_configured_files = ['configured.cpp']
 
     run_command_default_assertions(
         command=command,
-        cmake_trace=cmake_trace,
+        detect_configured_files=detect_configured_files,
         exit_success=not parsing_failed,
         **setup_command._asdict(),
     )


### PR DESCRIPTION
This PR introduces support for detecting files that have been generated using the `configure_file(...)` CMake function and running the hooks on them.

In practice, this means that during the call to CMake configure, `--trace-expand --trace-format=json-v1 --trace-redirect=...` arguments are appended to the regular CMake arguments in order to generate a JSON log file. From this log file, all the relevant calls to `configure_file()` are extracted (ignoring calls that originate from outside the specified source directory). Those files are then automatically added to any hook execution (e.g. in addition to files specified on the command line).

Fixes #47 