### PR TITLE
Fix Windows CI and update Python version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+        exclude:
+          # Python 3.10 has issues on macOS M1 runners (missing gettext/libintl)
+          - runs-on: macos-latest
+            python: '3.10'
 
     name: "Unit tests • ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
@@ -76,6 +80,10 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+        exclude:
+          # Python 3.10 has issues on macOS M1 runners (missing gettext/libintl)
+          - runs-on: macos-latest
+            python: '3.10'
 
     name: "System tests ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,19 +17,10 @@ jobs:
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
         python:
-          - 3.8
-          - 3.9
           - '3.10'
           - '3.11'
           - '3.12'
-        exclude:
-          # macos-latest is now running on M1 macs
-          - runs-on: macos-latest
-            python: 3.8
-          - runs-on: macos-latest
-            python: 3.9
-          - runs-on: macos-latest
-            python: 3.10
+          - '3.13'
 
     name: "Unit tests • ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
@@ -81,19 +72,10 @@ jobs:
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
         python:
-          - 3.8
-          - 3.9
           - '3.10'
           - '3.11'
           - '3.12'
-        exclude:
-          # macos-latest is now running on M1 macs
-          - runs-on: macos-latest
-            python: 3.8
-          - runs-on: macos-latest
-            python: 3.9
-          - runs-on: macos-latest
-            python: 3.10
+          - '3.13'
 
     name: "System tests ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}
@@ -143,9 +125,6 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install -y llvm ninja
-          # Install cppcheck via scoop instead of choco (choco package is broken)
-          iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-          scoop install cppcheck
           if (!(Test-Path -Path $PROFILE)) {
               New-Item -ItemType File -Path $PROFILE -Force
           }
@@ -162,14 +141,13 @@ jobs:
           . $PROFILE
           Get-Location
 
-          # Add scoop shims to PATH for this job
-          $scoopShims = "$env:USERPROFILE\scoop\shims"
-          Write-Output "PATH=$scoopShims;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Output "CMAKE_PREFIX_PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-          python -m pip install pre-commit cpplint lizard
+          # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
+          python -m pip install pre-commit cpplint lizard cppcheck
 
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
+          cppcheck --version
 
       - name: Build and install package
         run: python -m pip install -e .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,14 +133,8 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install -y llvm ninja
-
-          # Set up Visual Studio environment for this step only (not in PROFILE)
           Import-Module "${ENV:ChocolateyInstall}\helpers\chocolateyProfile.psm1"
           Update-SessionEnvironment
-          $id = vswhere -property instanceId
-          Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-          Enter-VsDevShell -InstanceId $id
-          Set-Location -Path "${ENV:GITHUB_WORKSPACE}"
 
           # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
           python -m pip install pre-commit cpplint lizard cppcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,10 @@ jobs:
       - name: Prepare env (Windows)
         if: runner.os == 'Windows'
         run: |
-          choco install -y llvm cppcheck ninja
+          choco install -y llvm ninja
+          # Install cppcheck via scoop instead of choco (choco package is broken)
+          iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+          scoop install cppcheck
           if (!(Test-Path -Path $PROFILE)) {
               New-Item -ItemType File -Path $PROFILE -Force
           }
@@ -159,6 +162,9 @@ jobs:
           . $PROFILE
           Get-Location
 
+          # Add scoop shims to PATH for this job
+          $scoopShims = "$env:USERPROFILE\scoop\shims"
+          Write-Output "PATH=$scoopShims;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Output "CMAKE_PREFIX_PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           python -m pip install pre-commit cpplint lizard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,16 @@ jobs:
           . $PROFILE
           Get-Location
 
+          # Restore Python path after VsDevShell (it resets PATH and uses system Python 3.9)
+          $env:PATH = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH"
+          Write-Output "PATH=$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Output "CMAKE_PREFIX_PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
           python -m pip install pre-commit cpplint lizard cppcheck
 
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
+          python --version
           cppcheck --version
 
       - name: Build and install package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,18 +132,32 @@ jobs:
           Import-Module "${ENV:ChocolateyInstall}\helpers\chocolateyProfile.psm1"
           Update-SessionEnvironment
 
+          # Restore Python to PATH after Update-SessionEnvironment (it resets PATH from system)
+          $env:PATH = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH"
+
           # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
           python -m pip install pre-commit cpplint lizard cppcheck
 
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
-          python --version
-          cppcheck --version
 
       # Enable MSVC dev command AFTER chocolatey packages are installed to avoid
       # Update-SessionEnvironment overwriting MSVC environment variables
       - name: Enable Developer Command Prompt
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1.13.0
+
+      # Restore Python to front of PATH after MSVC setup
+      # (MSVC's vcvarsall.bat prepends paths including VS's bundled Python 3.9,
+      # which conflicts with our Python 3.10+ requirement)
+      - name: Restore Python PATH
+        if: runner.os == 'Windows'
+        run: |
+          "$env:pythonLocation" >> $env:GITHUB_PATH
+          "$env:pythonLocation\Scripts" >> $env:GITHUB_PATH
+          # Ensure python3 also points to the correct Python (pre-commit looks for python3)
+          if (-not (Test-Path "$env:pythonLocation\python3.exe")) {
+            Copy-Item "$env:pythonLocation\python.exe" "$env:pythonLocation\python3.exe"
+          }
 
       - name: Build and install package
         run: python -m pip install -e .[test]
@@ -160,6 +174,8 @@ jobs:
           CC: cl
           CXX: cl
           LOGLEVEL: DEBUG
+          # Use a fresh pre-commit cache to avoid Python version mismatch
+          PRE_COMMIT_HOME: ${{ runner.temp }}/pre-commit-cache
         run: ./tests/run_tests.ps1
 
   sonarcloud:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,26 +133,14 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           choco install -y llvm ninja
-          if (!(Test-Path -Path $PROFILE)) {
-              New-Item -ItemType File -Path $PROFILE -Force
-          }
 
-          Write-Output 'Import-Module "${ENV:ChocolateyInstall}\helpers\chocolateyProfile.psm1"' | Out-File -FilePath $PROFILE -Append -Encoding utf8
-          Write-Output 'Update-SessionEnvironment' | Out-File -FilePath $PROFILE -Append -Encoding utf8
-          Write-Output '$id = vswhere -property instanceId' | Out-File -FilePath $PROFILE -Append -Encoding utf8
-          Write-Output 'Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"' `
-          | Out-File -FilePath $PROFILE -Append -Encoding utf8
-          Write-Output 'Enter-VsDevShell -InstanceId $id' | Out-File -FilePath $PROFILE -Append -Encoding utf8
-          Write-Output 'Set-Location -Path "${ENV:GITHUB_WORKSPACE}"' | Out-File -FilePath $PROFILE -Append -Encoding utf8
-          Get-Content -Path $PROFILE
-
-          . $PROFILE
-          Get-Location
-
-          # Restore Python path after VsDevShell (it resets PATH and uses system Python 3.9)
-          $env:PATH = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH"
-          Write-Output "PATH=$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Output "CMAKE_PREFIX_PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          # Set up Visual Studio environment for this step only (not in PROFILE)
+          Import-Module "${ENV:ChocolateyInstall}\helpers\chocolateyProfile.psm1"
+          Update-SessionEnvironment
+          $id = vswhere -property instanceId
+          Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -InstanceId $id
+          Set-Location -Path "${ENV:GITHUB_WORKSPACE}"
 
           # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
           python -m pip install pre-commit cpplint lizard cppcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,6 @@ jobs:
           git fetch --prune --unshallow
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Enable Developer Command Prompt
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1.13.0
-
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -142,6 +138,12 @@ jobs:
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
           python --version
           cppcheck --version
+
+      # Enable MSVC dev command AFTER chocolatey packages are installed to avoid
+      # Update-SessionEnvironment overwriting MSVC environment variables
+      - name: Enable Developer Command Prompt
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1.13.0
 
       - name: Build and install package
         run: python -m pip install -e .[test]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed PowerShell system test script using `$?` instead of `$LASTEXITCODE` for exit code handling
+
 ### Repository
+
+- Fixed Windows CI by using Scoop instead of Chocolatey to install cppcheck (Chocolatey package is broken)
 
 - Clarify where to put the settings in `pyproject.toml`
 - Update GitHub Action `actions/download-artifact` to v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop support for Python 3.8 and 3.9 (end-of-life)
+- Add support for Python 3.13
+- Minimum required Python version is now 3.10
+
 ### Fixed
 
 - Fixed PowerShell system test script using `$?` instead of `$LASTEXITCODE` for exit code handling
 
 ### Repository
 
-- Fixed Windows CI by using Scoop instead of Chocolatey to install cppcheck (Chocolatey package is broken)
+- Fixed Windows CI by using pip to install cppcheck (Chocolatey package is broken)
 
 - Clarify where to put the settings in `pyproject.toml`
 - Update GitHub Action `actions/download-artifact` to v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = 'pre-commit hooks for CMake-based projects'
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.10'
 keywords = [
 ]
 license = {text = 'Apache2'}
@@ -19,11 +19,10 @@ classifiers = [
      'License :: OSI Approved :: Apache Software License',
      'Programming Language :: Python :: 3',
      'Programming Language :: Python :: 3 :: Only',
-     'Programming Language :: Python :: 3.8',
-     'Programming Language :: Python :: 3.9',
      'Programming Language :: Python :: 3.10',
      'Programming Language :: Python :: 3.11',
      'Programming Language :: Python :: 3.12',
+     'Programming Language :: Python :: 3.13',
 ]
 dependencies = [
     'toml',
@@ -66,7 +65,7 @@ namespaces = false
 
 [tool.ruff]
 line-length = 120
-target-version = 'py38'
+target-version = 'py310'
 
 [tool.ruff.lint]
 

--- a/tests/run_tests.ps1
+++ b/tests/run_tests.ps1
@@ -84,11 +84,11 @@ cp .pre-commit-win.yaml .pre-commit-win.yaml.bak
 git add *.txt *.cpp .pre-commit*.yaml
 git commit -m 'Initial commit'
 pre-commit run -c .pre-commit-win.yaml --all-files
-$ret=$?
+$ret=$LASTEXITCODE
 mv -Force .pre-commit-win.yaml.bak .pre-commit-win.yaml
 rm -Force -Recurse .git
-if ($ret -eq 0) {
-    echo "Pre-commit on tests/cmake_good failed!"
+if ($ret -ne 0) {
+    echo "Pre-commit on tests/cmake_good failed with exit code $ret!"
     Exit 1
 }
 cd ../..
@@ -102,10 +102,10 @@ cp .pre-commit-win.yaml .pre-commit-win.yaml.bak
 git add *.txt *.cpp .pre-commit*.yaml
 git commit -m 'Initial commit'
 pre-commit run -c .pre-commit-win.yaml --all-files
-$ret=$?
+$ret=$LASTEXITCODE
 mv -Force .pre-commit-win.yaml.bak .pre-commit-win.yaml
 rm -Force -Recurse .git
-if ($ret -eq 1) {
+if ($ret -eq 0) {
     echo "Pre-commit on tests/cmake_bad unexpectedly passed!"
     Exit 1
 }


### PR DESCRIPTION
## Summary

- Fix Windows system tests that have been failing in CI
- Drop support for EOL Python versions and add Python 3.13

## Changes

### 1. Fix PowerShell exit code handling (`tests/run_tests.ps1`)

- Replace `$?` with `$LASTEXITCODE` for proper exit code capture
- Fix inverted test logic: `cmake_good` should fail when exit code != 0, `cmake_bad` should fail when exit code == 0
- Add exit code to error message for easier debugging

`$?` in PowerShell is a boolean (`True`/`False`), not the actual exit code. The correct way to capture external program exit codes is `$LASTEXITCODE`.

### 2. Fix broken cppcheck installation (`.github/workflows/ci.yml`)

The Chocolatey cppcheck package was compiled with a hardcoded `FILESDIR` path that doesn't exist on GitHub Actions runners. Additionally, Strawberry Perl (pre-installed on Windows runners) bundles a broken cppcheck that was being picked up.

**Fix:** Use the `cppcheck` pip wheel package which works correctly.

### 3. Update Python version support

- Drop Python 3.8 and 3.9 (end-of-life)
- Add Python 3.13 support
- Minimum Python version is now 3.10
- Update ruff target-version to py310

## Test plan

- [ ] Windows system tests pass in CI
- [ ] Linux system tests continue to pass
- [ ] macOS system tests continue to pass
- [ ] Unit tests pass for Python 3.10, 3.11, 3.12, 3.13