### PR TITLE
Fix Windows CI: move MSVC dev cmd after chocolatey install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,6 @@ jobs:
           git fetch --prune --unshallow
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Enable Developer Command Prompt
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1.13.0
-
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
@@ -142,6 +138,12 @@ jobs:
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
           python --version
           cppcheck --version
+
+      # Enable MSVC dev command AFTER chocolatey packages are installed to avoid
+      # Update-SessionEnvironment overwriting MSVC environment variables
+      - name: Enable Developer Command Prompt
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1.13.0
 
       - name: Build and install package
         run: python -m pip install -e .[test]


### PR DESCRIPTION
## Summary
- Move the `Enable Developer Command Prompt` step to run after Chocolatey packages are installed
- This fixes the issue where `Update-SessionEnvironment` was overwriting MSVC environment variables set by `ilammy/msvc-dev-cmd`

## Test plan
- [ ] Windows CI system tests should now pass for all Python versions (3.10, 3.11, 3.12, 3.13)