### PR TITLE
Fix Windows CI: restore Python PATH after MSVC setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,15 +135,10 @@ jobs:
           # Restore Python to PATH after Update-SessionEnvironment (it resets PATH from system)
           $env:PATH = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH"
 
-          # Verify we're using the correct Python
-          Write-Host "Python executable: $(Get-Command python | Select-Object -First 1 -ExpandProperty Source)"
-          python --version
-
           # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
           python -m pip install pre-commit cpplint lizard cppcheck
 
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
-          cppcheck --version
 
       # Enable MSVC dev command AFTER chocolatey packages are installed to avoid
       # Update-SessionEnvironment overwriting MSVC environment variables
@@ -163,22 +158,6 @@ jobs:
           if (-not (Test-Path "$env:pythonLocation\python3.exe")) {
             Copy-Item "$env:pythonLocation\python.exe" "$env:pythonLocation\python3.exe"
           }
-
-      - name: Verify Python PATH
-        if: runner.os == 'Windows'
-        run: |
-          Write-Host "Python location: $env:pythonLocation"
-          Write-Host "PATH entries (first 10):"
-          $env:PATH -split ';' | Select-Object -First 10
-          Write-Host "`nWhich python:"
-          Get-Command python -ErrorAction SilentlyContinue | Select-Object -First 3
-          python --version
-          Write-Host "`nWhich python3:"
-          Get-Command python3 -ErrorAction SilentlyContinue | Select-Object -First 3
-          Write-Host "`nWhich pre-commit:"
-          Get-Command pre-commit -ErrorAction SilentlyContinue | Select-Object -First 3
-          Write-Host "`nPre-commit Python:"
-          python -c "import sys; print(sys.executable)"
 
       - name: Build and install package
         run: python -m pip install -e .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,8 +151,20 @@ jobs:
       - name: Restore Python PATH
         if: runner.os == 'Windows'
         run: |
-          echo "$env:pythonLocation" >> $env:GITHUB_PATH
-          echo "$env:pythonLocation\Scripts" >> $env:GITHUB_PATH
+          "$env:pythonLocation" >> $env:GITHUB_PATH
+          "$env:pythonLocation\Scripts" >> $env:GITHUB_PATH
+
+      - name: Verify Python PATH
+        if: runner.os == 'Windows'
+        run: |
+          Write-Host "Python location: $env:pythonLocation"
+          Write-Host "PATH entries (first 5):"
+          $env:PATH -split ';' | Select-Object -First 5
+          Write-Host "Which python:"
+          Get-Command python | Select-Object -First 1
+          python --version
+          Write-Host "Which pre-commit:"
+          Get-Command pre-commit | Select-Object -First 1
 
       - name: Build and install package
         run: python -m pip install -e .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,15 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1.13.0
 
+      # Restore Python to front of PATH after MSVC setup
+      # (MSVC's vcvarsall.bat prepends paths including VS's bundled Python 3.9,
+      # which conflicts with our Python 3.10+ requirement)
+      - name: Restore Python PATH
+        if: runner.os == 'Windows'
+        run: |
+          echo "$env:pythonLocation" >> $env:GITHUB_PATH
+          echo "$env:pythonLocation\Scripts" >> $env:GITHUB_PATH
+
       - name: Build and install package
         run: python -m pip install -e .[test]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,18 +153,26 @@ jobs:
         run: |
           "$env:pythonLocation" >> $env:GITHUB_PATH
           "$env:pythonLocation\Scripts" >> $env:GITHUB_PATH
+          # Ensure python3 also points to the correct Python (pre-commit looks for python3)
+          if (-not (Test-Path "$env:pythonLocation\python3.exe")) {
+            Copy-Item "$env:pythonLocation\python.exe" "$env:pythonLocation\python3.exe"
+          }
 
       - name: Verify Python PATH
         if: runner.os == 'Windows'
         run: |
           Write-Host "Python location: $env:pythonLocation"
-          Write-Host "PATH entries (first 5):"
-          $env:PATH -split ';' | Select-Object -First 5
-          Write-Host "Which python:"
-          Get-Command python | Select-Object -First 1
+          Write-Host "PATH entries (first 10):"
+          $env:PATH -split ';' | Select-Object -First 10
+          Write-Host "`nWhich python:"
+          Get-Command python -ErrorAction SilentlyContinue | Select-Object -First 3
           python --version
-          Write-Host "Which pre-commit:"
-          Get-Command pre-commit | Select-Object -First 1
+          Write-Host "`nWhich python3:"
+          Get-Command python3 -ErrorAction SilentlyContinue | Select-Object -First 3
+          Write-Host "`nWhich pre-commit:"
+          Get-Command pre-commit -ErrorAction SilentlyContinue | Select-Object -First 3
+          Write-Host "`nPre-commit Python:"
+          python -c "import sys; print(sys.executable)"
 
       - name: Build and install package
         run: python -m pip install -e .[test]
@@ -181,6 +189,8 @@ jobs:
           CC: cl
           CXX: cl
           LOGLEVEL: DEBUG
+          # Use a fresh pre-commit cache to avoid Python version mismatch
+          PRE_COMMIT_HOME: ${{ runner.temp }}/pre-commit-cache
         run: ./tests/run_tests.ps1
 
   sonarcloud:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,17 @@ jobs:
           Import-Module "${ENV:ChocolateyInstall}\helpers\chocolateyProfile.psm1"
           Update-SessionEnvironment
 
+          # Restore Python to PATH after Update-SessionEnvironment (it resets PATH from system)
+          $env:PATH = "$env:pythonLocation;$env:pythonLocation\Scripts;$env:PATH"
+
+          # Verify we're using the correct Python
+          Write-Host "Python executable: $(Get-Command python | Select-Object -First 1 -ExpandProperty Source)"
+          python --version
+
           # Install cppcheck via pip (choco package is broken, pip wheel works correctly)
           python -m pip install pre-commit cpplint lizard cppcheck
 
           Get-Command @("python", "clang-format", "clang-tidy", "cppcheck", "cpplint", "lizard", "pre-commit")
-          python --version
           cppcheck --version
 
       # Enable MSVC dev command AFTER chocolatey packages are installed to avoid


### PR DESCRIPTION
## Summary

Fixes the Windows CI system tests that were failing due to Python version mismatch.

## Problem

The `ilammy/msvc-dev-cmd` action runs Visual Studio's `vcvarsall.bat`, which **prepends** VS paths to PATH. Visual Studio 2022 bundles Python 3.9, so after msvc-dev-cmd runs, Python 3.9 takes precedence over the Python 3.10+ set up by `actions/setup-python`.

When pre-commit later creates its isolated environment to install the `cmake-pre-commit-hooks` package, it uses the now-in-front Python 3.9, which fails with:
```
ERROR: Package 'cmake-pre-commit-hooks' requires a different Python: 3.9.13 not in '>=3.10'
```

## Solution

Add a step after `ilammy/msvc-dev-cmd` that writes the correct Python path to `GITHUB_PATH`, which prepends it in subsequent steps:

```yaml
- name: Restore Python PATH
  if: runner.os == 'Windows'
  run: |
    echo "$env:pythonLocation" >> $env:GITHUB_PATH
    echo "$env:pythonLocation\Scripts" >> $env:GITHUB_PATH
```

This ensures pre-commit uses the correct Python 3.10+ version when installing hooks.

## Test plan

- [ ] Windows system tests pass for Python 3.10, 3.11, 3.12, 3.13