### PR TITLE
Merge Dependabot and pre-commit.ci updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
           name: coverage
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -30,7 +30,7 @@ jobs:
           python3 -m mdformat CHANGELOG.md
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         id: make-commit
         with:
           branch: release/${{ github.event.inputs.tag }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,14 +51,14 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.1
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
         args: [-S, -l, '120']
         additional_dependencies: [black==22.12.0]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.9
+    rev: v0.14.10
     hooks:
       - id: ruff-format
         name: ruff (format)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `github.com/codespell-project/codespell` hook to v2.4.1
 - Update `github.com/shellcheck-py/shellcheck-py` hook to v0.11.0.1
 - Update `github.com/adrienverge/yamllint.git` hook to v1.37.1
-- Update `github.com/asottile/blacken-docs` hook to 1.19.1
-- Update `github.com/astral-sh/ruff-pre-commit` hook to v0.12.9
+- Update `github.com/asottile/blacken-docs` hook to 1.20.0
+- Update `github.com/astral-sh/ruff-pre-commit` hook to v0.14.10
 
 ## [v1.9.6] - 2024-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub Action `actions/download-artifact` to v4
 - Update GitHub Action `actions/upload-artifact` to v4
 - Update GitHub Action `codecov/codecov-action` from v4 to v5
-- Use GitHub Action `SonarSource/sonarqube-scan-action` v5
+- Use GitHub Action `SonarSource/sonarqube-scan-action` v7
+- Update GitHub Action `github/codeql-action` from v3 to v4
+- Update GitHub Action `stefanzweifel/git-auto-commit-action` from v5 to v7
 - Update `github.com/pre-commit/pre-commit-hooks` hook to v6.0.0
 - Update `https://github.com/PyCQA/doc8/` hook to v2.0.0
 - Update `github.com/codespell-project/codespell` hook to v2.4.1

--- a/cmake_pc_hooks/_argparse.py
+++ b/cmake_pc_hooks/_argparse.py
@@ -145,11 +145,11 @@ def _load_data_from_toml(
     except FileNotFoundError as err:
         if path_must_exist:
             raise TOMLFileNotFoundError(path) from err
-        log.debug('TOML file %s does not exist (not an error)', str(path))
+        log.debug('TOML file %s does not exist (not an error)', path)
     except KeyError as err:
         if section_must_exist:
             raise TOMLSectionKeyError(section, path) from err
-        log.debug('TOML file %s does not have a %s section (not an error)', str(path), section)
+        log.debug('TOML file %s does not have a %s section (not an error)', path, section)
     else:
         return config
     return {}

--- a/cmake_pc_hooks/_cmake.py
+++ b/cmake_pc_hooks/_cmake.py
@@ -271,7 +271,7 @@ class CMakeCommand:
             if build_dir.exists() and Path(build_dir, 'CMakeCache.txt').exists():
                 log.debug(
                     'Located valid build directory with CMakeCache.txt at: %s',
-                    str(build_dir),
+                    build_dir,
                 )
                 self.build_dir = build_dir.resolve()
                 return
@@ -280,7 +280,7 @@ class CMakeCommand:
         if automatic_discovery:
             for path in sorted(self.source_dir.glob('*')):
                 if path.is_dir() and (path / 'CMakeCache.txt').exists():
-                    log.info('Automatic build dir discovery resulted in: %s', str(path))
+                    log.info('Automatic build dir discovery resulted in: %s', path)
                     self.build_dir = path
                     return
 
@@ -295,7 +295,7 @@ class CMakeCommand:
             self.build_dir = Path(build_dir_list[0]).resolve()
         log.info(
             'Unable to locate a valid build directory. Will be creating one at %s',
-            str(self.build_dir),
+            self.build_dir,
         )
 
     def setup_cmake_args(self, cmake_args):  # noqa: C901
@@ -532,8 +532,8 @@ class CMakeCommand:
                 configured_file = self.build_dir / configured_file
             log.debug(
                 'detected call to configure_file(%s %s [...])',
-                str(input_file),
-                str(configured_file),
+                input_file,
+                configured_file,
             )
             self.cmake_configured_files.append(str(configured_file))
 

--- a/cmake_pc_hooks/_utils.py
+++ b/cmake_pc_hooks/_utils.py
@@ -173,7 +173,7 @@ class Command(hooks.utils.Command):  # pylint: disable=too-many-instance-attribu
         for build_dir in build_dir_list:
             path = Path(build_dir, 'compile_commands.json')
             if build_dir.exists() and path.exists():
-                log.debug('Located valid compilation database at: %s', str(path))
+                log.debug('Located valid compilation database at: %s', path)
                 return path
         log.debug('No valid compilation database located')
         return None


### PR DESCRIPTION
## Summary

### GitHub Actions (Dependabot)
- Update `SonarSource/sonarqube-scan-action` from v5 to v7
- Update `github/codeql-action` from v3 to v4
- Update `stefanzweifel/git-auto-commit-action` from v5 to v7

### Pre-commit hooks (pre-commit.ci)
- Update `blacken-docs` hook from 1.19.1 to 1.20.0
- Update `ruff-pre-commit` hook from v0.12.9 to v0.14.10

This PR consolidates the following PRs:
- #124 (pre-commit.ci autoupdate)
- #128 (github/codeql-action v3 → v4)
- #129 (stefanzweifel/git-auto-commit-action v5 → v7)
- #130 (SonarSource/sonarqube-scan-action v5 → v7)

Note: PR #127 (sonarqube-scan-action v5→v6) was skipped because PR #130 supersedes it.

## Test plan

- [ ] Verify CI workflows pass
- [ ] Verify CodeQL analysis runs correctly with v4
- [ ] Verify SonarCloud scan works with v7
- [ ] Verify pre-commit hooks work with updated versions