### PR TITLE
Fix SonarCloud violations

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -13,7 +13,16 @@ jobs:
   new-release:
     name: "Draft a new release"
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag }}
     steps:
+      - name: Validate release tag format
+        run: |
+          if ! echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Tag must be in format vXX.YY.ZZ"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Setup Python
@@ -26,7 +35,7 @@ jobs:
       - name: Update CHANGELOG
         run: |
           python3 -m pip install mdformat-gfm 'git+https://github.com/Takishima/keepachangelog@v1.0.1'
-          python3 -m keepachangelog release "${{ github.event.inputs.tag }}"
+          python3 -m keepachangelog release "$RELEASE_TAG"
           python3 -m mdformat CHANGELOG.md
 
       - name: Commit changes

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,16 +28,18 @@ jobs:
           curl -LsSf "${source_url}/${parse_changelog_tag}/parse-changelog-${target}.tar.gz" | tar xzf -
       - name: Extract version from branch name (for release branches)
         if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release/')
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#release/v}
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
           git tag v${RELEASE_VERSION}
 
       - name: Extract version from branch name (for hotfix branches)
         if: github.event_name == 'pull_request'  && startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#hotfix/v}
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
           git tag v${RELEASE_VERSION}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -39,16 +39,18 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         if: github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'release/')
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#release/}
           VERSION=${VERSION#v}
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Extract version from branch name (for hotfix branches)
         if: github.event_name == 'pull_request'  && startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#hotfix/}
           VERSION=${VERSION#v}
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,8 +31,10 @@ jobs:
           python3 -m pip install 'git+https://github.com/Takishima/pre-commit-changelog-auto-update@v1.0.0'
 
       - name: Run Python script
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          python3 -m update_changelog --pr-body "${{ github.event.pull_request.body }}"
+          python3 -m update_changelog --pr-body "$PR_BODY"
 
       - name: Commit changes
         id: commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Repository
 
+- Fix SonarCloud violations:
+  - Fix return type annotation for `_load_from_toml` method in `_argparse.py`
+  - Reduce cognitive complexity in `_cmake.py` by extracting helper methods
+  - Reduce cognitive complexity in `_cmake_test.py` by extracting test helpers
+  - Fix variable naming conventions in test files
+  - Fix GitHub Actions security issues by using environment variables for user-controlled data
+  - Add input validation for workflow_dispatch parameters
+  - Fix shell script issues in `run_tests.sh` (use `[[` instead of `[`, add return statements)
 - Fixed Windows CI by using pip to install cppcheck (Chocolatey package is broken)
 - Modernize ruff configuration to follow latest guidelines
   - Remove deprecated settings (`target-version`, `ANN101`, `ASYNC1`, etc.)

--- a/cmake_pc_hooks/_argparse.py
+++ b/cmake_pc_hooks/_argparse.py
@@ -293,7 +293,7 @@ class ArgumentParser(argparse.ArgumentParser):
         path_must_exist: bool = True,
         section_must_exist: bool = True,
         overridable_keys: set | None = None,
-    ) -> None:
+    ) -> argparse.Namespace:
         """
         Load a TOML file and set the attributes within the argparse namespace object.
 


### PR DESCRIPTION
## Summary

This PR fixes multiple SonarCloud violations across the codebase:

### Python Code Fixes
- **`cmake_pc_hooks/_argparse.py`**: Fixed return type annotation for `_load_from_toml` method (was `None`, now correctly `argparse.Namespace`)
- **`cmake_pc_hooks/_cmake.py`**: Reduced cognitive complexity by extracting helper methods (`_process_keyword_cmake_args`, `_process_flag_cmake_args`, `_process_platform_cmake_args`)
- **`tests/python/_cmake_test.py`**:
  - Reduced cognitive complexity by extracting test helper functions
  - Renamed `InterProcessReaderWriterLock` → `mock_rw_lock` and `FileLock` → `mock_file_lock` to follow naming conventions

### GitHub Actions Security Fixes
- **`.github/workflows/pull_request.yml`**: Use environment variable for PR body instead of direct interpolation to prevent command injection
- **`.github/workflows/format.yml`**: Use environment variables for branch names in run commands
- **`.github/workflows/publish_release.yml`**: Use environment variables for branch names in run commands
- **`.github/workflows/draft_release.yml`**: Added tag format validation step and use environment variable for run commands

### Shell Script Fixes
- **`tests/run_tests.sh`**:
  - Replaced `[ ]` with `[[ ]]` for safer conditional tests
  - Added explicit `return` statements at end of functions
  - Merged nested if conditions where applicable

## Test plan
- [x] All 91 Python tests pass
- [ ] CI pipeline passes